### PR TITLE
Facility to build a platform native application

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,11 @@
                     <artifactId>maven-gpg-plugin</artifactId>
                     <version>1.4</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>1.6.0</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -297,6 +302,40 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>native</id>
+            <build>
+                <plugins>
+                    <!-- uses graal-vm to build a native image -->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <executable>native-image</executable>
+                            <workingDirectory>${project.build.directory}</workingDirectory>
+                            <arguments>
+                                <argument>-da</argument>
+                                <argument>--class-path</argument>
+                                <classpath/>
+                                <argument>uk.gov.nationalarchives.utf8.validator.Utf8ValidateCmd</argument>
+                                <argument>utf8validate</argument>
+                            </arguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
     
      <pluginRepositories>
         <pluginRepository>


### PR DESCRIPTION
Makes use of GraalVM to build a native binary for the platform the application is compiled on.
See - https://blog.adamretter.org.uk/graalvm-utf-8-validation/